### PR TITLE
Converting average statistics to Long for clarity in the report.

### DIFF
--- a/src/main/scala/com/jnpersson/slacken/KrakenReport.scala
+++ b/src/main/scala/com/jnpersson/slacken/KrakenReport.scala
@@ -203,9 +203,9 @@ class TotalKmerCountReport(taxonomy: Taxonomy, counts: Array[(Taxon, Long)], val
     s"${super.dataColumnHeaders}\tTKC1-LeafOnly\tTKC2-FirstChildren\tTKC3-AllChildren"
 
   override def dataColumns(taxid: Taxon): String = {
-    val totMinSizeS1 = totMinAgg.totKmerAverageS1(taxid)
-    val totMinSizeS2 = totMinAgg.totKmerAverageS2(taxid)
-    val totMinSizeS3 = totMinAgg.totKmerAverageS3(taxid)
+    val totMinSizeS1 = math.ceil(totMinAgg.totKmerAverageS1(taxid)).toLong
+    val totMinSizeS2 = math.ceil(totMinAgg.totKmerAverageS2(taxid)).toLong
+    val totMinSizeS3 = math.ceil(totMinAgg.totKmerAverageS3(taxid)).toLong
     s"${super.dataColumns(taxid)}\t$totMinSizeS1\t$totMinSizeS2\t$totMinSizeS3"
 
   }


### PR DESCRIPTION
Kmer count averages for all 3 types of averaging have been converted to Long for clarity.