### PR TITLE
Converted kmer count averages to Long for clarity.

### DIFF
--- a/src/main/scala/com/jnpersson/slacken/KrakenReport.scala
+++ b/src/main/scala/com/jnpersson/slacken/KrakenReport.scala
@@ -203,9 +203,9 @@ class TotalKmerCountReport(taxonomy: Taxonomy, counts: Array[(Taxon, Long)], val
     s"${super.dataColumnHeaders}\tTKC1-LeafOnly\tTKC2-FirstChildren\tTKC3-AllChildren"
 
   override def dataColumns(taxid: Taxon): String = {
-    val totMinSizeS1 = math.ceil(totMinAgg.totKmerAverageS1(taxid)).toLong
-    val totMinSizeS2 = math.ceil(totMinAgg.totKmerAverageS2(taxid)).toLong
-    val totMinSizeS3 = math.ceil(totMinAgg.totKmerAverageS3(taxid)).toLong
+    val totMinSizeS1 = math.round(totMinAgg.totKmerAverageS1(taxid)).toLong
+    val totMinSizeS2 = math.round(totMinAgg.totKmerAverageS2(taxid)).toLong
+    val totMinSizeS3 = math.round(totMinAgg.totKmerAverageS3(taxid)).toLong
     s"${super.dataColumns(taxid)}\t$totMinSizeS1\t$totMinSizeS2\t$totMinSizeS3"
 
   }


### PR DESCRIPTION
Kmer count averages for all 3 types of averaging have been converted to Long for clarity.